### PR TITLE
Mint GitHub App token in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -16,10 +16,16 @@ jobs:
         if: |
           (!(github.event.head_commit.message == 'Update package version'))
         steps:
+            - name: Generate GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                app-id: ${{ secrets.APP_ID }}
+                private-key: ${{ secrets.APP_PRIVATE_KEY }}
             - name: Checkout repo
               uses: actions/checkout@v4
               with:
-                token: ${{ secrets.POLICYENGINE_GITHUB }}
+                token: ${{ steps.app-token.outputs.token }}
                 fetch-depth: 0
             - name: Setup Python
               uses: actions/setup-python@v5
@@ -35,6 +41,8 @@ jobs:
               with:
                 add: "."
                 message: Update package version
+                github_token: ${{ steps.app-token.outputs.token }}
+                fetch: false
     publish-to-pypi:
       name: Publish to PyPI
       if: (github.event.head_commit.message == 'Update package version')

--- a/changelog.d/migrate-to-app-token.fixed.md
+++ b/changelog.d/migrate-to-app-token.fixed.md
@@ -1,0 +1,1 @@
+Migrated versioning workflow from expired `POLICYENGINE_GITHUB` PAT to a short-lived GitHub App token, matching the pattern used by `policyengine-us`, `policyengine-core`, and `microdf`.


### PR DESCRIPTION
## Summary

The `POLICYENGINE_GITHUB` PAT referenced by `.github/workflows/versioning.yaml` expired on 2026-01-12. Without a valid token, the versioning job's checkout step fails with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

so the `Update package version` commit never gets pushed and nothing publishes to PyPI.

## Fix

Swap the PAT for a short-lived GitHub App token minted via `actions/create-github-app-token@v1`, using the org-level `APP_ID` / `APP_PRIVATE_KEY` secrets. Matches the pattern already applied to `microdf` (#296), `policyengine-core` (#470), `policyengine-us`, and the country repos.

Also pass the app token to `EndBug/add-and-commit` and disable its pre-commit fetch so the auto-generated `Update package version` commit pushes successfully and triggers the downstream PyPI publish job.

Benefits over renewing the PAT:
- No annual expiry to chase
- Not tied to any one person's account
- Pushes by the App token still trigger downstream workflows (required here so the committed `Update package version` commit fires the publish job)

## Test plan

- [x] `yaml.safe_load` confirms the workflow parses
- [ ] After merge: next versioning push (when a `changelog.d/` fragment lands on `main`) should produce an `Update package version` commit -> PyPI publish fires

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>